### PR TITLE
Fix #68

### DIFF
--- a/src/debian/install
+++ b/src/debian/install
@@ -1,4 +1,5 @@
 usr/bin/brightness-controller usr/bin/
+usr/bin/brightness-reset usr/bin/
 usr/share/icons/hicolor/scalable/apps/brightness-controller.svg usr/share/icons/hicolor/scalable/apps/
 usr/share/icons/hicolor/16x16/apps/brightness-controller.png usr/share/icons/hicolor/16x16/apps/
 usr/share/applications/brightness-controller.desktop usr/share/applications/

--- a/src/usr/bin/brightness-reset
+++ b/src/usr/bin/brightness-reset
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 
-import wx
 import subprocess
 from os import system
 
-class BrightnessRestore(wx.Frame):
+class BrightnessRestore():
 
     def detect_display_devices(self):
         """Detects available displays"""
@@ -28,6 +27,4 @@ class BrightnessRestore(wx.Frame):
 
 
 if __name__ == '__main__':
-    app = wx.App()
     BrightnessRestore()
-    app.MainLoop()

--- a/src/usr/bin/brightness-reset
+++ b/src/usr/bin/brightness-reset
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+import wx
+import subprocess
+from os import system
+
+class BrightnessRestore(wx.Frame):
+
+    def detect_display_devices(self):
+        """Detects available displays"""
+        connected_devs = []
+        xrandr_output = subprocess.check_output('xrandr -q', shell=True)
+        lines = xrandr_output.split('\n')
+        for line in lines:
+            words = line.split(' ')
+            for word in words:
+                if word == 'connected':
+                    connected_devs.append(words[0])
+        return connected_devs
+
+    def __init__(self):
+        self.detected_devices = self.detect_display_devices()
+	self.primary_name = self.detected_devices[0]
+	cmd1 = "xrandr --output \
+                %s --brightness %s" % (self.primary_name, 1)
+	system(cmd1)
+
+
+if __name__ == '__main__':
+    app = wx.App()
+    BrightnessRestore()
+    app.MainLoop()


### PR DESCRIPTION
Something like this can be implemented in v2 too.

In the new version (to be packaged) brightness will return to 100% in primary monitor if the command `brightness-reset` is run 